### PR TITLE
Remove deprecated t_Co option

### DIFF
--- a/lua/space-nvim.lua
+++ b/lua/space-nvim.lua
@@ -11,13 +11,11 @@ local _TYPE_TABLE  = 'table'
 
 -- Determine which set of colors to use.
 local _USE_HEX = vim.o.termguicolors
-local _USE_256 = tonumber(vim.o.t_Co) > 255
-	or string.find(vim.env.TERM, '256')
+local _USE_256 = string.find(vim.env.TERM, '256')
 
 -- Determine which set of colors to use.
 local _USE_HEX = vim.o.termguicolors
-local _USE_256 = tonumber(vim.o.t_Co) > 255
-    or string.find(vim.env.TERM, '256')
+local _USE_256 = string.find(vim.env.TERM, '256')
     
 
 --[[ HELPER FUNCTIONS ]]


### PR DESCRIPTION
Neovim has removed the `t_Co` option. Attempting to reference it causes an error when loading the color scheme. This PR removes the `t_Co` option and only uses the `TERM` environment variable.