### PR TITLE
Fixed a problem where find.string returns a bad argument

### DIFF
--- a/lua/space-nvim.lua
+++ b/lua/space-nvim.lua
@@ -11,12 +11,12 @@ local _TYPE_TABLE  = 'table'
 
 -- Determine which set of colors to use.
 local _USE_HEX = vim.o.termguicolors
-local _USE_256 = string.find(vim.env.TERM, '256')
-
--- Determine which set of colors to use.
-local _USE_HEX = vim.o.termguicolors
-local _USE_256 = string.find(vim.env.TERM, '256')
-    
+local _USE_256
+if vim.env.TERM then
+	_USE_256 = string.find(vim.env.TERM, '256')
+else
+	_USE_256 = nil
+end
 
 --[[ HELPER FUNCTIONS ]]
 


### PR DESCRIPTION
On Windows, I got the following error:

```
Error detected while processing $ENV:LOCALAPPDATA\nvim-data\site\pack\packer\start\space-nvim\colors\space-nvim.vim:
line  859:
E5108: Error executing lua ...ata\site\pack\packer\start\space-nvim/lua/space-nvim.lua:14: bad argument #1 to 'find' (string expected, got nil)
stack traceback:
        [C]: in function 'find'
        ...ata\site\pack\packer\start\space-nvim/lua/space-nvim.lua:14: in main chunk
        [C]: in function 'require'
        [string ":lua"]:853: in main chunk

```

I provided a fix.
