### PR TITLE
Improving error message visibility

### DIFF
--- a/colors/space-nvim.vim
+++ b/colors/space-nvim.vim
@@ -186,7 +186,7 @@ local highlight_groups = {
     DiffDelete = {fg = red, style = 'reverse'}, -- diff mode: Deleted line
     DiffText = {fg = yellow, style = 'reverse'}, -- diff mode: Changed text within a changed line
     EndOfBuffer = {fg = bg0}, -- filler lines (~) after the last line in the buffer
-    ErrorMsg = {fg = bg0, bg = bg1}, -- error messages on the command line
+    ErrorMsg = {fg = red1, bg = bg1}, -- error messages on the command line
     VertSplit = {fg = bg1}, -- the column separating verti-- cally split windows
     Folded = {fg = purple2, bg = bg1, style = 'italic'}, -- line used for closed folds
     FoldColumn = {fg = purple0}, -- 'foldcolumn'


### PR DESCRIPTION
Relating to this issue: https://github.com/Th3Whit3Wolf/space-nvim/issues/6
This changes the text color of error messages to improve visibility
Before:
![image](https://github.com/Th3Whit3Wolf/space-nvim/assets/47261410/8f1ef7dd-862a-4fd7-ae6e-f3741b0b30c8)
After:
![image](https://github.com/Th3Whit3Wolf/space-nvim/assets/47261410/e3b4ed93-b863-49d3-9a90-ad5b99b01488)
![image](https://github.com/Th3Whit3Wolf/space-nvim/assets/47261410/4eb69bb8-eabb-4fc4-b7c9-c487d3c5588e)
